### PR TITLE
Don't default ip to '0.0.0.0', leave it as null

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -13,7 +13,6 @@ module.exports = (beg, p..., cb)->
     end = 65534
   else
     end ?= 65534
-    ip ?= '0.0.0.0'
   cnt ?= 1
 
   retcb = cb


### PR DESCRIPTION
This avoids strange errors, where it would return a port that is already bound
